### PR TITLE
Add Alertlogic troubleshooting submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "alertlogiccli/commands/troubleshooting"]
+	path = alertlogiccli/commands/troubleshooting
+	url = git@algithub.pd.alertlogic.net:defender/alertlogic-cli-troubleshooting.git

--- a/alertlogic-cli
+++ b/alertlogic-cli
@@ -47,7 +47,7 @@ def bug_report_traceback():
            "{}")
     return msg.format(traceback.format_exc())
 
-def parse_args():
+def parse_args(services):
     parser = argparse.ArgumentParser(description="alertlogic cloud insight client")
 
     parser.add_argument("--logging_config_file", help="use a specific configuration file for logging")
@@ -60,7 +60,7 @@ def parse_args():
     parser.add_argument("-a", "--account_id", help="use a specific account (managed accounts only)")
     subparsers = parser.add_subparsers(title="commands", description="valid commands", dest="command")
 
-    commands = import_command_modules(subparsers)
+    commands = import_command_modules(subparsers, services)
     args = parser.parse_args()
     return {'commands': commands, 'args': args}
 
@@ -84,10 +84,9 @@ def make_config(args):
         config.account_id = args.account_id
     return config
 
-def run_command(args, commands):
+def run_command(args, commands, services):
     config = make_config(args)
     session = config.make_session()
-    services = alertlogic.dynapi.Services()
     services.set_session(session)
 
     if args.environment_id is None:
@@ -105,12 +104,12 @@ def main():
 
     if not import_dependencies():
         sys.exit(2)
-
-    context = parse_args()
+    services = alertlogic.dynapi.Services()
+    context = parse_args(services)
     args = context['args']
     try:
         init_logging(args)
-        result = run_command(args, context['commands'])
+        result = run_command(args, context['commands'], services)
         print(result)
         sys.exit(0)
     except (alertlogic.auth.AuthenticationException,

--- a/alertlogic-cli
+++ b/alertlogic-cli
@@ -84,7 +84,11 @@ def make_config(args):
         config.account_id = args.account_id
     return config
 
-def run_command(args, commands, services):
+def run_command(services):
+    context = parse_args(services)
+    commands = context['commands']
+    args = context['args']
+    init_logging(args)
     config = make_config(args)
     session = config.make_session()
     services.set_session(session)
@@ -105,11 +109,8 @@ def main():
     if not import_dependencies():
         sys.exit(2)
     services = alertlogic.dynapi.Services()
-    context = parse_args(services)
-    args = context['args']
     try:
-        init_logging(args)
-        result = run_command(args, context['commands'], services)
+        result = run_command(services)
         print(result)
         sys.exit(0)
     except (alertlogic.auth.AuthenticationException,

--- a/alertlogic/dynapi.py
+++ b/alertlogic/dynapi.py
@@ -26,10 +26,18 @@ class Services():
     more info: http://apidocjs.com
     """
     def __init__(self):
-        for service_name in API_SERVICES:
-            filename = API_DATA_DIR+"/"+service_name+".json"
+        self.add_services(API_SERVICES, API_DATA_DIR)
+
+    def add_services(self, api_services, api_data_dir):
+        for service_name in api_services:
+            filename = api_data_dir + "/" + service_name + ".json"
             service = self.parse_apidoc_file(filename)
-            self.__dict__[service_name] = service
+            if self.__dict__.has_key(service_name):
+                currentapi = self.__dict__[service_name]
+                currentapi.merge_api(service)
+                self.__dict__[service_name]._endpoints
+            else:
+                self.__dict__[service_name] = service
 
     def parse_apidoc_file(self, filename):
         """generates a Service() object by parsing an apidoc json file
@@ -67,9 +75,13 @@ class Service():
     """Stores a set of Endpoint()s and allows to call them dynamically as functions
     by using metaprogramming
     """
+
     def __init__(self):
         self._endpoints = {}
         self._session = None
+
+    def merge_api(self, service):
+        self._endpoints.update(service._endpoints)
 
     def add_endpoint(self, name, operation, url):
         """Creates and stores an Endpoint() see Endpoint class for more info

--- a/alertlogic/dynapi.py
+++ b/alertlogic/dynapi.py
@@ -35,7 +35,6 @@ class Services():
             if self.__dict__.has_key(service_name):
                 currentapi = self.__dict__[service_name]
                 currentapi.merge_api(service)
-                self.__dict__[service_name]._endpoints
             else:
                 self.__dict__[service_name] = service
 

--- a/alertlogiccli/commands/__init__.py
+++ b/alertlogiccli/commands/__init__.py
@@ -80,7 +80,7 @@ def filter_command_classes(module_path, baseClass):
 #     second element is subcommand ``command`` class attribute
 #   value is command class object
 #
-def import_command_modules(subparsers):
+def import_command_modules(subparsers, services):
     commands_module_path, = alertlogiccli.commands.__path__
     commands_modules = filter(lambda (loader, name, ispkg): ispkg, pkgutil.walk_packages(path=[commands_module_path]))
 
@@ -92,6 +92,10 @@ def import_command_modules(subparsers):
         ## single module class per command module is expected
         [ModuleClass] = filter_command_classes('alertlogiccli.commands.' + module_name, CLIModule)
         func = getattr(ModuleClass, 'get_parser')
+        if  hasattr(ModuleClass, 'extend_api'):
+            extend_api_fun = getattr(ModuleClass, 'extend_api')
+            extend_api_fun(services)
+
         module_parsers = func(subparsers)
         ModuleClassCmd = getattr(ModuleClass, 'command')
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 VERSION = '1.2.0'
 setup(
     name = 'alertlogic_cli',
-    packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
+    packages=find_packages(exclude=['contrib', 'docs', 'tests*', 'troubleshooting']),
     scripts = ['alertlogic-cli'],
     version = VERSION,
     license='MIT',


### PR DESCRIPTION
### Problem
Alertlogic support people need private commands set plugin in order to execute support activities

### Resolution
Make it possible to extend base API client in the submodules
Add git submodule which will be only available from within AL